### PR TITLE
fix icon size, fetch special icons and colors properly

### DIFF
--- a/src/PurchaseItemPopup.cpp
+++ b/src/PurchaseItemPopup.cpp
@@ -26,30 +26,111 @@ class $modify(PurchaseItemPopup)
                 money->setString(std::to_string(std::atoi(money->getString()) - parameters->m_Price).c_str());
                 
                 //update icon
-                CCMenuItemSpriteExtra* iconButton = static_cast<CCMenuItemSpriteExtra*>(
-                    getChildOfType<CCMenu>(
-                        getChildOfType<ListButtonPage>(
-                            getChildOfType<ExtendedLayer>(
-                                getChildOfType<BoomScrollLayer>(
-                                    getChildOfType<ListButtonBar>(
-                                        garage, 0
+                CCMenuItemSpriteExtra *iconButton;
+                switch (parameters->m_UnlockType) {
+                    case UnlockType::ShipFire:
+                        iconButton = static_cast<CCMenuItemSpriteExtra*>(
+                            getChildOfType<CCMenu>(
+                                getChildOfType<ListButtonPage>(
+                                    getChildOfType<ExtendedLayer>(
+                                        getChildOfType<BoomScrollLayer>(
+                                            getChildOfType<ListButtonBar>(
+                                                getChildOfType<ListButtonBar>(
+                                                    garage, 0
+                                                ), 0
+                                            ), 0
+                                        ), 0
                                     ), 0
                                 ), 0
-                            ), 0
-                        ), 0
-                    )->getChildByTag(parameters->m_IconId)
-                );
+                            )->getChildByTag(parameters->m_IconId)
+                        );
+                        break;
+                  case UnlockType::GJItem:
+                      iconButton = static_cast<CCMenuItemSpriteExtra*>(
+                          getChildOfType<CCMenu>(
+                              getChildOfType<ListButtonBar>(garage, 0), 0
+                          )->getChildByTag(parameters->m_IconId)
+                      );
+                      break;
+                  case UnlockType::Col1:
+                  case UnlockType::Col2:
+                      iconButton = static_cast<CCMenuItemSpriteExtra*>(
+                          getChildOfType<CCMenu>(
+                              getChild<CCLayer>(
+                                  getChildOfType<CharacterColorPage>(
+                                    garage, 0
+                                  ), 0
+                              ), 0
+                          )->getChildByID(std::to_string(parameters->m_IconId).c_str())
+                      );
+                      break;
+                  default:
+                      iconButton = static_cast<CCMenuItemSpriteExtra*>(
+                          getChildOfType<CCMenu>(
+                              getChildOfType<ListButtonPage>(
+                                  getChildOfType<ExtendedLayer>(
+                                      getChildOfType<BoomScrollLayer>(
+                                          getChildOfType<ListButtonBar>(
+                                              garage, 0
+                                          ), 0
+                                      ), 0
+                                  ), 0
+                              ), 0
+                          )->getChildByTag(parameters->m_IconId)
+                      );
+                      break;
+                }
+
+                if (iconButton == nullptr) {
+                  garage->removeChildByID("BUInode");
+                  CCTouchDispatcher::get()->unregisterForcePrio(getChildOfType<ItemInfoPopup>(scene, 0));
+                  scene->removeChild(getChildOfType<ItemInfoPopup>(scene, 0));
+                  ProfilePage* profile = getChildOfType<ProfilePage>(scene, 0);
+                  if (profile != nullptr)
+                      scene->removeChild(static_cast<CCNode*>(scene->getChildren()->objectAtIndex(scene->getChildrenCount()-1)));
+                  return;
+                }
                 iconButton->removeAllChildren();
                 
+                float scale;
+                switch (parameters->m_UnlockType) {
+                    case UnlockType::Cube: scale = 0.8f; break;
+                    case UnlockType::Ship: scale = 0.6f; break;
+                    case UnlockType::Ball: scale = 0.75f; break;
+                    case UnlockType::Bird: scale = 0.68f; break;
+                    case UnlockType::Dart: scale = 0.8f; break;
+                    case UnlockType::Robot: scale = 0.65f; break;
+                    case UnlockType::Spider: scale = 0.65f; break;
+                    case UnlockType::Swing: scale = 0.7f; break;
+                    case UnlockType::Jetpack: scale = 0.6f; break;
+                    case UnlockType::Streak: scale = 0.8f; break;
+                    case UnlockType::ShipFire: scale = 0.8f; break;
+                    case UnlockType::GJItem: scale = 0.8f; break;
+                    case UnlockType::Col1: scale = 0.65f; break;
+                    case UnlockType::Col2: scale = 0.65f; break;
+                }
                 //create unlocked icon
-                GJItemIcon* newIcon = GJItemIcon::createBrowserItem(parameters->m_UnlockType, parameters->m_IconId);
-                newIcon->setTag(1);
-                newIcon->setPosition(CCPoint(15, 15));
-                newIcon->setScale(0.8f);
-                iconButton->addChild(newIcon);
+                if (parameters->m_UnlockType == UnlockType::Col1 || parameters->m_UnlockType == UnlockType::Col2) {
+                    ColorChannelSprite* newIcon = ColorChannelSprite::create();
+                    newIcon->setTag(1);
+                    newIcon->setPosition(CCPoint(11.537, 11.862));
+                    newIcon->setColor(GameManager::get()->colorForIdx(parameters->m_IconId));
+                    newIcon->setScale(scale);
+                    iconButton->addChild(newIcon);
+                    CCSprite* fakeLock = CCSprite::create();
+                    fakeLock->setTag(100);
+                    newIcon->addChild(fakeLock);
+                } else {
+                    GJItemIcon* newIcon = GJItemIcon::createBrowserItem(parameters->m_UnlockType, parameters->m_IconId);
+                    newIcon->setTag(1);
+                    newIcon->setPosition(CCPoint(15, 15));
+                    newIcon->setScale(scale);
+                    iconButton->addChild(newIcon);
+                }
                 
                 garage->removeChildByID("BUInode");
 
+                CCTouchDispatcher::get()->unregisterForcePrio(getChildOfType<ItemInfoPopup>(scene, 0));
                 scene->removeChild(getChildOfType<ItemInfoPopup>(scene, 0));
             }
             


### PR DESCRIPTION
Icons have different scales depending on the type, so it's not always 0.8f. This adjusts the scale accordingly.

Special icons (like ship fires, animations, and colors) are not in the structure you are using to get their buttons, causing them to fail. This handles those cases.

Also unregisters force prio prior to deleting the popup.


CharacterColorPage crashes if you buy a color, and then switch to a different tab. Not sure what the cause is atm.